### PR TITLE
docs: READEME.md add first three steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Rename `.env.example` to `.env` and add `OPENAI_API_KEY`
 
 **Step 3**
 
-Use the command `bunx enso src/cli.ts https://path/to/url`
+Use the command `bunx tsx src/cli.ts https://path/to/url`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # url-system
 
+**Step 1**
+
+Install [bun](https://github.com/oven-sh/bun#install)
+
+**Step 2**
+
+Rename `.env.example` to `.env` and add `OPENAI_API_KEY`
+
+**Step 3**
+
+Use the command `bunx enso src/cli.ts https://path/to/url`


### PR DESCRIPTION
> From v0.15, `esno` is essentially an alias of [`tsx`](https://github.com/esbuild-kit/tsx), with automated CJS/ESM mode and caching.

according to https://github.com/esbuild-kit/esno#readme